### PR TITLE
-Add optional shape_dist_traveled

### DIFF
--- a/sql/stop_times.sql
+++ b/sql/stop_times.sql
@@ -9,6 +9,7 @@ CREATE TABLE `stop_times` (
 	stop_headsign VARCHAR(50),
 	pickup_type INT(2),
 	drop_off_type INT(2),
+	shape_dist_traveled VARCHAR(50)
 	KEY `trip_id` (trip_id),
 	KEY `arrival_time_seconds` (arrival_time_seconds),
 	KEY `departure_time_seconds` (departure_time_seconds),


### PR DESCRIPTION
Adding optional shape_dist_travelled attribute so that there is no error while parsing a gtfs file having this attribute
