### PR TITLE
Fixed typo in sql/stop_times.sql and added missing parts to README

### DIFF
--- a/README
+++ b/README
@@ -19,12 +19,16 @@ DEAD-SIMPLE USAGE:
 
 	cat sql/*.sql | mysql -p -u USERNAME -h HOST -D gtfs
 	
-3. Run the import script:
+3. Edit settings.py with your mysql details.
+
+4. Put your GTFS files into the gtfs/ folder
+
+5. Run the import script:
 
 	python load_gtfs.py
 	
-4. Run the time index creation script:
+6. Run the time index creation script:
 
 	python build_indices.py
 	
-5. Build something neat
+7. Build something neat

--- a/sql/stop_times.sql
+++ b/sql/stop_times.sql
@@ -9,7 +9,7 @@ CREATE TABLE `stop_times` (
 	stop_headsign VARCHAR(50),
 	pickup_type INT(2),
 	drop_off_type INT(2),
-	shape_dist_traveled VARCHAR(50)
+	shape_dist_traveled VARCHAR(50),
 	KEY `trip_id` (trip_id),
 	KEY `arrival_time_seconds` (arrival_time_seconds),
 	KEY `departure_time_seconds` (departure_time_seconds),


### PR DESCRIPTION
One of the lines in sql/stop_times.sql's CREATE TABLE was missing a comma at the end of the line. Added it.
Added to README two steps; modifying settings.py and placing gtfs files in place.
